### PR TITLE
Revert "Depend on AudioKit main instead of v5-main, now v5 is published"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
             targets: ["AudioKitUI"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/AudioKit/AudioKit.git", .branch("main"))
+        .package(url: "https://github.com/AudioKit/AudioKit.git", .branch("v5-main"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
Reverts beamsfm/AudioKitUI#1